### PR TITLE
Fix for go 1.10: Removed -w flag and fixed CGO warning. Removed not needed spaces.

### DIFF
--- a/callbacks.c
+++ b/callbacks.c
@@ -1,65 +1,65 @@
 #include "sciter-x.h"
 #include "_cgo_export.h"
 
-// typedef BOOL SC_CALLBACK SciterElementCallback( HELEMENT he, LPVOID param );
+// typedef BOOL SC_CALLBACK SciterElementCallback(HELEMENT he, LPVOID param);
 
 BOOL SC_CALLBACK SciterElementCallback_cgo(HELEMENT he, LPVOID param)
 {
     return goSciterElementCallback(he, param);
 }
 
-// typedef VOID SC_CALLBACK LPCBYTE_RECEIVER( LPCBYTE bytes, UINT num_bytes, LPVOID param );
-VOID SC_CALLBACK LPCBYTE_RECEIVER_cgo( LPCBYTE bytes, UINT num_bytes, LPVOID param )
+// typedef VOID SC_CALLBACK LPCBYTE_RECEIVER(LPCBYTE bytes, UINT num_bytes, LPVOID param);
+VOID SC_CALLBACK LPCBYTE_RECEIVER_cgo(LPCBYTE bytes, UINT num_bytes, LPVOID param)
 {
-    goLPCBYTE_RECEIVER(bytes, num_bytes, param);
+    goLPCBYTE_RECEIVER((BYTE*)bytes, num_bytes, param);
 }
 
-// typedef VOID SC_CALLBACK LPCWSTR_RECEIVER( LPCWSTR str, UINT str_length, LPVOID param );
-VOID SC_CALLBACK LPCWSTR_RECEIVER_cgo( LPCWSTR str, UINT str_length, LPVOID param )
+// typedef VOID SC_CALLBACK LPCWSTR_RECEIVER(LPCWSTR str, UINT str_length, LPVOID param);
+VOID SC_CALLBACK LPCWSTR_RECEIVER_cgo(LPCWSTR str, UINT str_length, LPVOID param)
 {
-    goLPCWSTR_RECEIVER(str, str_length, param);
+    goLPCWSTR_RECEIVER((WCHAR*)str, str_length, param);
 }
 
-// typedef VOID SC_CALLBACK LPCSTR_RECEIVER( LPCSTR str, UINT str_length, LPVOID param );
-VOID SC_CALLBACK LPCSTR_RECEIVER_cgo( LPCSTR str, UINT str_length, LPVOID param )
+// typedef VOID SC_CALLBACK LPCSTR_RECEIVER(LPCSTR str, UINT str_length, LPVOID param);
+VOID SC_CALLBACK LPCSTR_RECEIVER_cgo(LPCSTR str, UINT str_length, LPVOID param)
 {
-    goLPCSTR_RECEIVER(str, str_length, param);
+    goLPCSTR_RECEIVER((CHAR*)str, str_length, param);
 }
 
-// typedef BOOL SC_CALLBACK ElementEventProc(LPVOID tag, HELEMENT he, UINT evtg, LPVOID prms );
-BOOL SC_CALLBACK ElementEventProc_cgo(LPVOID tag, HELEMENT he, UINT evtg, LPVOID prms )
+// typedef BOOL SC_CALLBACK ElementEventProc(LPVOID tag, HELEMENT he, UINT evtg, LPVOID prms);
+BOOL SC_CALLBACK ElementEventProc_cgo(LPVOID tag, HELEMENT he, UINT evtg, LPVOID prms)
 {
-    return goElementEventProc( tag,  he,  evtg,  prms );
+    return goElementEventProc(tag, he, evtg, prms);
 }
 
-// typedef UINT SC_CALLBACK SciterHostCallback( LPSCITER_CALLBACK_NOTIFICATION pns, LPVOID callbackParam );
-UINT SC_CALLBACK SciterHostCallback_cgo( LPSCITER_CALLBACK_NOTIFICATION pns, LPVOID callbackParam )
+// typedef UINT SC_CALLBACK SciterHostCallback(LPSCITER_CALLBACK_NOTIFICATION pns, LPVOID callbackParam);
+UINT SC_CALLBACK SciterHostCallback_cgo(LPSCITER_CALLBACK_NOTIFICATION pns, LPVOID callbackParam)
 {
     return goSciterHostCallback(pns, callbackParam);
 }
 
-// typedef VOID NATIVE_FUNCTOR_INVOKE( VOID* tag, UINT argc, const VALUE* argv, VALUE* retval); // retval may contain error definition
-VOID NATIVE_FUNCTOR_INVOKE_cgo( VOID* tag, UINT argc, const VALUE* argv, VALUE* retval)
+// typedef VOID NATIVE_FUNCTOR_INVOKE(VOID* tag, UINT argc, const VALUE* argv, VALUE* retval); // retval may contain error definition
+VOID NATIVE_FUNCTOR_INVOKE_cgo(VOID* tag, UINT argc, const VALUE* argv, VALUE* retval)
 {
-    goNATIVE_FUNCTOR_INVOKE(tag, argc, argv, retval);
+    goNATIVE_FUNCTOR_INVOKE(tag, argc, (VALUE*)argv, retval);
 }
 
-// typedef VOID NATIVE_FUNCTOR_RELEASE( VOID* tag );
-VOID NATIVE_FUNCTOR_RELEASE_cgo( VOID* tag )
+// typedef VOID NATIVE_FUNCTOR_RELEASE(VOID* tag);
+VOID NATIVE_FUNCTOR_RELEASE_cgo(VOID* tag)
 {
     goNATIVE_FUNCTOR_RELEASE(tag);
 }
 
-// typedef INT SC_CALLBACK ELEMENT_COMPARATOR( HELEMENT he1, HELEMENT he2, LPVOID param );
+// typedef INT SC_CALLBACK ELEMENT_COMPARATOR(HELEMENT he1, HELEMENT he2, LPVOID param);
 
-INT SC_CALLBACK ELEMENT_COMPARATOR_cgo( HELEMENT he1, HELEMENT he2, LPVOID param )
+INT SC_CALLBACK ELEMENT_COMPARATOR_cgo(HELEMENT he1, HELEMENT he2, LPVOID param)
 {
     goELEMENT_COMPARATOR(he1, he2, param);
 }
 
-// typedef BOOL SC_CALLBACK KeyValueCallback( LPVOID param, const VALUE* pkey, const VALUE* pval );
+// typedef BOOL SC_CALLBACK KeyValueCallback(LPVOID param, const VALUE* pkey, const VALUE* pval);
 
-BOOL SC_CALLBACK KeyValueCallback_cgo(LPVOID param, const VALUE* pkey, const VALUE* pval )
+BOOL SC_CALLBACK KeyValueCallback_cgo(LPVOID param, const VALUE* pkey, const VALUE* pval)
 {
-    return goKeyValueCallback( param,  pkey,  pval );
+    return goKeyValueCallback(param, (VALUE*)pkey, (VALUE*)pval);
 }

--- a/sciter.go
+++ b/sciter.go
@@ -5,7 +5,7 @@
 package sciter
 
 /*
-#cgo CFLAGS: -g -w -std=c11 -Iinclude -DPLAIN_API_ONLY
+#cgo CFLAGS: -g -std=c11 -Iinclude -DPLAIN_API_ONLY
 #cgo linux LDFLAGS: -ldl
 #cgo linux pkg-config: gtk+-3.0
 #include "sciter-x.h"
@@ -1623,8 +1623,8 @@ func (e *Element) IsEnabled() bool {
 }
 
 //export goELEMENT_COMPARATOR
-func goELEMENT_COMPARATOR(he1 unsafe.Pointer, he2 unsafe.Pointer, arg uintptr) int {
-	cmp := *(*func(*Element, *Element) int)(unsafe.Pointer(arg))
+func goELEMENT_COMPARATOR(he1 unsafe.Pointer, he2 unsafe.Pointer, arg unsafe.Pointer) int {
+	cmp := *(*func(*Element, *Element) int)(arg)
 	return cmp(WrapElement(C.HELEMENT(he1)), WrapElement(C.HELEMENT(he2)))
 }
 


### PR DESCRIPTION
I fixed the problem for go 1.10 not  compiling because of cgo -w flag. After removing this flag cgo started showing warnings so I fixed them as well. Also I changed code style for callback.c file because there were mismatch in spacing after  '(' and before ')' parentheses :)