### PR TITLE
Add: Support for custom DLL location

### DIFF
--- a/include/value.h
+++ b/include/value.h
@@ -1,6 +1,8 @@
 #ifndef __value_h__
 #define __value_h__
 
+const char * DLL_DIR;
+
 #include "sciter-x-types.h"
 
 enum VALUE_RESULT

--- a/sciter-x-api.c
+++ b/sciter-x-api.c
@@ -1,6 +1,7 @@
 #include <sciter-x.h>
 
 // getting ISciterAPI reference:
+const char * DLL_DIR = "sciter.dll";
 
 #ifdef STATIC_LIB
 
@@ -31,7 +32,7 @@
        if( ext ) _api = ext;
        if( !_api )
        {
-          HMODULE hm = LoadLibrary( TEXT("sciter.dll") );
+          HMODULE hm = LoadLibrary( TEXT( DLL_DIR ) );
           //#if defined(WIN64) || defined(_WIN64)
           //  TEXT("sciter64.dll")
           //#else

--- a/sciter.go
+++ b/sciter.go
@@ -76,6 +76,10 @@ func (s *Sciter) GetHwnd() C.HWINDOW {
 	return s.hwnd
 }
 
+func SetDLL(dir string){
+	C.DLL_DIR = C.CString(dir)
+}
+
 //This function is used in response to SCN_LOAD_DATA request.
 //
 //  \param[in] hwnd \b HWINDOW, Sciter window handle.


### PR DESCRIPTION
New function `SetDLL(dir string)` allow set the place where the `sciter.dll`, instead of use the [Dynamic-Link Library Search Order](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682586(v=vs.85).aspx).  #112 