### PR TITLE
Workaround for issue #245

### DIFF
--- a/include/sciter-x-types.h
+++ b/include/sciter-x-types.h
@@ -381,6 +381,8 @@ typedef VOID SC_CALLBACK LPCBYTE_RECEIVER( LPCBYTE str, UINT num_bytes, LPVOID p
 
 #define STDCALL __stdcall
 
+#define HWINDOW_PTR HWINDOW*
+
 #ifdef __cplusplus
 
   #define EXTERN_C extern "C"

--- a/sciter.go
+++ b/sciter.go
@@ -1049,7 +1049,7 @@ func (e *Element) GetHwnd(rootWindow bool) (hwnd C.HWINDOW, err error) {
 		crootWindow = C.TRUE
 	}
 	// cgo call
-	r := C.SciterGetElementHwnd(e.handle, &hwnd, crootWindow)
+	r := C.SciterGetElementHwnd(e.handle, (C.HWINDOW_PTR)(unsafe.Pointer(&hwnd)), crootWindow)
 	err = wrapDomResult(r, "SciterGetElementHwnd")
 	return
 }


### PR DESCRIPTION
Fixes "cannot use _cgo1 (type \*_Ctype_HWINDOW) as type \*\*_Ctype_struct__GtkWidget
in argument to _Cfunc_SciterGetElementHwnd" error in go 1.15.  This defines an explicit
pointer type for HWINDOW\* that is used to cast from the unsafe pointer that the cgo
compiler is happy converting to a GtkWidget\*\* for the function call.