### PR TITLE
Use absolute path for `LoadFile` in all examples

### DIFF
--- a/examples/callback/callback.go
+++ b/examples/callback/callback.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"log"
-
+	"filepath"
+	
 	"github.com/sciter-sdk/go-sciter"
 	"github.com/sciter-sdk/go-sciter/window"
 )
@@ -12,7 +13,11 @@ func main() {
 	if err != nil {
 		log.Fatal("Create Window Error: ", err)
 	}
-	w.LoadFile("index.html")
+	fullpath, err := filepath.Abs("index.html")
+	if err != nil {
+		log.Fatal(err)
+	}
+	w.LoadFile(fullpath)
 	setEventHandler(w)
 	w.Show()
 	w.Run()

--- a/examples/callback/callback.go
+++ b/examples/callback/callback.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"log"
-	"filepath"
+	"path/filepath"
 	
 	"github.com/sciter-sdk/go-sciter"
 	"github.com/sciter-sdk/go-sciter/window"

--- a/examples/demoes/01/demo1.go
+++ b/examples/demoes/01/demo1.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"log"
-
+	"path/filepath"
+	
 	"github.com/sciter-sdk/go-sciter"
 	"github.com/sciter-sdk/go-sciter/window"
 )
@@ -26,7 +27,11 @@ func main() {
 		log.Fatal(err)
 	}
 	//load file;加载文件
-	w.LoadFile("demo1.html")
+	fullpath, err := filepath.Abs("demo1.html")
+	if err != nil {
+		log.Fatal(err)
+	}
+	w.LoadFile(fullpath)
 	//set title; 设置标题
 	w.SetTitle("Hello, world")
 	//show;显示窗口

--- a/examples/demoes/04/demo4.go
+++ b/examples/demoes/04/demo4.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 
 	"github.com/sciter-sdk/go-sciter"
 	"github.com/sciter-sdk/go-sciter/window"
@@ -86,8 +87,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	w.LoadFile("demo4.html")
+	fullpath, err := filepath.Abs("demo4.html")
+	if err != nil {
+		log.Fatal(err)
+	}
+	w.LoadFile(fullpath)
 	//设置标题
 	w.SetTitle("事件处理")
 

--- a/examples/demoes/05/demo5.go
+++ b/examples/demoes/05/demo5.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"log"
-
+	"path/filepath"
+	
 	"github.com/sciter-sdk/go-sciter"
 	"github.com/sciter-sdk/go-sciter/window"
 )
@@ -15,7 +16,12 @@ func main() {
 		log.Fatal(err)
 	}
 	//加载文件
-	w.LoadFile("demo5.html")
+	fullpath, err := filepath.Abs("demo5.html")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	w.LoadFile(fullpath)
 	//设置标题
 	w.SetTitle("固定大小窗口")
 	//显示窗口

--- a/examples/demoes/06/demo6.go
+++ b/examples/demoes/06/demo6.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 
 	"github.com/sciter-sdk/go-sciter"
 	"github.com/sciter-sdk/go-sciter/window"
@@ -58,7 +59,12 @@ func main() {
 		log.Fatal(err)
 	}
 	//加载文件
-	w.LoadFile("demo6.html")
+	fullpath, err := filepath.Abs("demo6.html")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	w.LoadFile(fullpath")
 	//设置标题
 	w.SetTitle("元素加载内容")
 	//获取根元素

--- a/examples/demoes/07/demo7.go
+++ b/examples/demoes/07/demo7.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 
 	"github.com/sciter-sdk/go-sciter"
 	"github.com/sciter-sdk/go-sciter/window"
@@ -32,7 +33,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	w.LoadFile("demo7.html")
+	fullpath, err := filepath.Abs("demo7.html")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	w.LoadFile(fullpath)
 	w.SetTitle("tiscript脚本学习")
 	defFunc(w)
 	w.Show()

--- a/examples/demoes/08/demo9.go
+++ b/examples/demoes/08/demo9.go
@@ -53,7 +53,12 @@ func main() {
 		log.Fatal(err)
 	}
 	w.SetOption(sciter.SCITER_SET_SCRIPT_RUNTIME_FEATURES, sciter.ALLOW_SYSINFO|sciter.ALLOW_FILE_IO)
-	w.LoadFile("demo9.html")
+	fullpath, err := filepath.Abs("demo9.html")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	w.LoadFile(fullpath)
 	w.SetTitle("view对象学习")
 	defFunc(w)
 	w.Show()

--- a/examples/fixed/fixedWindow.go
+++ b/examples/fixed/fixedWindow.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"log"
+	"path/filepath"
 
 	"github.com/sciter-sdk/go-sciter"
 	"github.com/sciter-sdk/go-sciter/window"
@@ -19,8 +20,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	w.LoadFile(flag.Arg(0))
+	fullpath, err := filepath.Abs(flag.Arg(0)) //if it's already an absolute path, it'll be returned as is.
+	if err != nil {
+		log.Fatal(err)
+	}
+	w.LoadFile(fullpath)
 	w.Show()
 	w.Run()
 }

--- a/examples/handlers/handlers.go
+++ b/examples/handlers/handlers.go
@@ -128,7 +128,12 @@ func main() {
 		log.Println("set debug mode failed")
 	}
 	// load file
-	if err = w.LoadFile(flag.Arg(0)); err != nil {
+	fullpath, err := filepath.Abs(flag.Arg(0))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err = w.LoadFile(fullpath); err != nil {
 		log.Println("LoadFile error:", err.Error())
 		return
 	}

--- a/examples/handlers/handlers.go
+++ b/examples/handlers/handlers.go
@@ -3,7 +3,8 @@ package main
 import (
 	"flag"
 	"log"
-
+	"path/filepath"
+	
 	"github.com/sciter-sdk/go-sciter"
 	"github.com/sciter-sdk/go-sciter/rice"
 	"github.com/sciter-sdk/go-sciter/window"


### PR DESCRIPTION
Hi
All examples that use normal relative paths got updated to use absolute path instead.
This should fix #223.

