### PR TITLE
Rename mac-lib sciter-osx-64.dylib -> libsciter.dylib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_cache:
 install:
   - export SDK_PATH=https://raw.githubusercontent.com/c-smile/sciter-sdk/master
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then curl -so "$TRAVIS_BUILD_DIR/libsciter-gtk.so" $SDK_PATH/bin.lnx/x64/libsciter-gtk.so; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx"   ]; then curl -so "$TRAVIS_BUILD_DIR/sciter-osx-64.dylib" $SDK_PATH/bin.osx/sciter-osx-64.dylib; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx"   ]; then curl -so "$TRAVIS_BUILD_DIR/libsciter.dylib" $SDK_PATH/bin.osx/libsciter.dylib; fi
 
 # - go get golang.org/x/lint/golint
 
@@ -58,7 +58,7 @@ install:
 
 before_script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$TRAVIS_BUILD_DIR"; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then cp "$TRAVIS_BUILD_DIR/sciter-osx-64.dylib" "$TRAVIS_BUILD_DIR/libsciter-osx-64.dylib"; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then cp "$TRAVIS_BUILD_DIR/libsciter.dylib" "$TRAVIS_BUILD_DIR/liblibsciter.dylib"; fi
 
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$TRAVIS_BUILD_DIR"; fi
 

--- a/include/sciter-x-types.h
+++ b/include/sciter-x-types.h
@@ -107,7 +107,7 @@ enum GFX_LAYER
 
   #if defined(WINDOWLESS)
     #define HWINDOW LPVOID
-  #else 
+  #else
   #define HWINDOW HWND
   #endif
 
@@ -154,10 +154,10 @@ enum GFX_LAYER
   typedef void* LPVOID;
   typedef const void* LPCVOID;
 
-  #define SCAPI  
+  #define SCAPI
   #define SCFN(name) (*name)
-  #define SC_CALLBACK 
-  #define CALLBACK 
+  #define SC_CALLBACK
+  #define CALLBACK
 
   typedef struct tagRECT
   {
@@ -191,14 +191,14 @@ enum GFX_LAYER
     #if defined(WINDOWLESS)
       #define SCITER_DLL_NAME "sciter-lite-64.dylib"
     #else
-    #define SCITER_DLL_NAME "sciter-osx-64.dylib"
+    #define SCITER_DLL_NAME "libsciter.dylib"
     #endif
   #else
     #define TARGET_32
     #if defined(WINDOWLESS)
       #define SCITER_DLL_NAME "sciter-lite-32.dylib"
     #else
-      #define SCITER_DLL_NAME "sciter-osx-64.dylib"
+      #define SCITER_DLL_NAME "libsciter.dylib"
     #endif
   #endif
 
@@ -261,11 +261,11 @@ enum GFX_LAYER
   } SIZE, *PSIZE, *LPSIZE;
 
 #if defined(WINDOWLESS)
-  #define HWINDOW void * 
-#else 
+  #define HWINDOW void *
+#else
   #define HWINDOW GtkWidget* //
 #endif
-  
+
   #define HINSTANCE LPVOID //
   #define LRESULT long
   #define HDC LPVOID       // cairo_t


### PR DESCRIPTION
After patch 4.4.6.3 https://rawgit.com/c-smile/sciter-sdk/master/logfile.htm library file was renamed from `sciter-osx-64.dylib` to `libsciter.dylib`