### PR TITLE
Click event should be triggered only once

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -54,7 +54,7 @@ func (e *eventMapper) addMethod(name string, nf func(args ...*Value) *Value) {
 
 func (e *eventMapper) onClick(fn func()) {
 	e.behaviorEventHandlerList = append(e.behaviorEventHandlerList, func(he *Element, params *BehaviorEventParams) bool {
-		if params.Cmd() == BUTTON_CLICK {
+		if params.Cmd() == BUTTON_CLICK && params.Phase() == SINKING {
 			fn()
 		}
 		return false


### PR DESCRIPTION
The button click event listener is triggered in both sinking and bubbling phase.
Should be triggered only once.