### PR TITLE
Fix sciter.NullValue()

### DIFF
--- a/value.go
+++ b/value.go
@@ -242,8 +242,8 @@ func (v *Value) IsNull() bool {
 // // static value null() { value n; n.t = T_NULL; return n; }
 func NullValue() *Value {
 	v := new(Value)
-	v.t = T_NULL
 	v.init()
+	v.t = T_NULL
 	return v
 }
 
@@ -255,8 +255,8 @@ func (v *Value) IsNothing() bool {
 // static value nothing() { value n; n.t = T_UNDEFINED; n.u = UT_NOTHING; return n; }
 func NothingValue() *Value {
 	v := new(Value)
+	v.init()
 	v.t = T_UNDEFINED
 	v.u = UT_NOTHING
-	v.init()
 	return v
 }


### PR DESCRIPTION
The function `sciter.NullValue()` currently creates `undefined` instead of `null`, because it sets value properties before initializing the value. Apparently `Value.init()` overrides field `t` with default values.

To verify the bug and the fix, try: `println(sciter.NullValue().IsNull(), sciter.NullValue().IsUndefined())`. Returns `false true` before and `true false` after fixed.