### PR TITLE
Fix boolean values - should be T_BOOL, not T_INT

### DIFF
--- a/value.go
+++ b/value.go
@@ -79,11 +79,7 @@ func (v *Value) Assign(val interface{}) {
 		v.SetFloat(f)
 	case bool:
 		// value( bool v )           { valueInit(this); valueIntDataSet(this, v?1:0, T_BOOL, 0); }
-		i := 0
-		if val.(bool) {
-			i = 1
-		}
-		v.SetInt(i)
+		v.SetBool(val.(bool))
 	case float32:
 		v.Assign(float64(val.(float32)))
 	case uint:


### PR DESCRIPTION
Currently boolean values are created by `sciter.NewValue` as `T_INT`, while sciter has `T_BOOL` for this. In Javascript, values are therefore represented as 1 and 0 instead of true and false. The code to properly set booleans is already present.

The bug can be reproduced by this code: 
```
v0 := sciter.NewValue(false)
println(v0.IsBool(), v0.Bool(), v0.IsInt())
v1 := sciter.NewValue(true)
println(v1.IsBool(), v1.Bool(), v1.IsInt())
```
The expected output should be ``true false false / true true false`, but is `false false true / false true true`. 